### PR TITLE
Fixes + docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5-alpine
+FROM python:2.7-alpine
 
 COPY requirements.txt /pkg/requirements.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.5-alpine
+
+COPY requirements.txt /pkg/requirements.txt
+
+RUN pip install -r /pkg/requirements.txt
+
+COPY index_cloner.py /index_cloner.py
+
+ENTRYPOINT ["python", "/index_cloner.py"]

--- a/README.md
+++ b/README.md
@@ -6,9 +6,14 @@ Clone one elastic search index to another
 - Clones documents along with mappings.
 - Configure shard and replica count for the newly created index
 
-Steps to execute:
+How to run on host machine:
 ----------------
 
 1. Clone repository
 2. run "pip install -r requirements.txt" to install dependencies
 3. run "python index_cloner -h" for help
+
+How to run using docker:
+----------------
+
+1. run "docker run -t --rm --net=host geslot/es-index-cloner:1.0 -h" for help


### PR DESCRIPTION
1. Retrieve whole index from ES, not only mappings. This way things like index settings, analyzers, etc. are being preserved.
2. Pop from responses instead of accessing them by index to support index cloning when accessing it by alias.
3. Added dockerfile to have ability to run index clone without installing python and python packages.